### PR TITLE
revise functor instance for `HFree`

### DIFF
--- a/src/Data/Functor/HFree.hs
+++ b/src/Data/Functor/HFree.hs
@@ -49,7 +49,7 @@ leftAdjunct :: (HFree c f :~> g) -> f :~> g
 leftAdjunct f = f . unit
 
 instance Functor (HFree c f) where
-  fmap f (HFree g) = HFree (fmap f . g)
+  fmap f h = HFree (\s -> fmap f (runHFree h s))
 
 hfmap :: (f :~> g) -> HFree c f :~> HFree c g
 hfmap f (HFree g) = HFree $ \k -> g (k . f)


### PR DESCRIPTION
ghc-8.0.1 was balking 

    src/Data/Functor/HFree.hs:52:30: error:
    • Could not deduce: (f b0 -> g b0) ~ (f :~> g)
      from the context: (c g, Functor g)
        bound by a type expected by the context:
                   (c g, Functor g) => f :~> g -> g b
        at src/Data/Functor/HFree.hs:52:14-40
      Expected type: (f b0 -> g b0) -> g a
        Actual type: f :~> g -> g a
    • In the second argument of ‘(.)’, namely ‘runHFree h’
      In the first argument of ‘HFree’, namely ‘(fmap f . runHFree h)’
      In the expression: HFree (fmap f . runHFree h)
    • Relevant bindings include
        h :: HFree c f a (bound at src/Data/Functor/HFree.hs:52:10)
        fmap :: (a -> b) -> HFree c f a -> HFree c f b
          (bound at src/Data/Functor/HFree.hs:52:3)

but this expansion seems to work fine.