### PR TITLE
Add Data.Functor.Free.TH to a cabal file

### DIFF
--- a/free-functors.cabal
+++ b/free-functors.cabal
@@ -34,6 +34,7 @@ Library
   exposed-modules:
     Data.Constraint.Class1,
     Data.Functor.Cofree,
+    Data.Functor.Free.TH
     Data.Functor.Free,
     Data.Functor.HCofree,
     Data.Functor.HFree,


### PR DESCRIPTION
I hope it will be fixed a problem with installing `free-functors` via stack or cabal